### PR TITLE
Ensure that generate pdf is machine readable (for ATS systems)

### DIFF
--- a/sourabh_bajaj_resume.tex
+++ b/sourabh_bajaj_resume.tex
@@ -17,6 +17,7 @@
 \usepackage{fancyhdr}
 \usepackage[english]{babel}
 \usepackage{tabularx}
+\usepackage{glyphtounicode}
 
 \pagestyle{fancy}
 \fancyhf{} % clear all header and footer fields
@@ -41,6 +42,9 @@
 \titleformat{\section}{
   \vspace{-4pt}\scshape\raggedright\large
 }{}{0em}{}[\color{black}\titlerule \vspace{-5pt}]
+
+% Ensure that generate pdf is machine readable/ATS parsable
+\pdfgentounicode=1
 
 %-------------------------
 % Custom commands


### PR DESCRIPTION
Hi,

Most resumes are now parsed by Applicant Tracking Systems and sometimes resumes written in latex are not parseable by ATS.
`\pdfgentounicode=1` from the `glypthtounicode` package ensures that the output pdf is parseable.

Thanks!