### PR TITLE
Github action to build pdf output

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,26 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  compile:
+    name: Compile resume pdf
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+          image: thomasweise/docker-texlive-full:latest
+          options: -v ${{ github.workspace }}:/data
+          run: |
+            cd data
+            pdflatex sourabh_bajaj_resume.tex
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply pdflatex changes

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Archieve/
 *.cb
 *.cb2
 .*.lb
+
+# github action result
+semicolon_delimited_script


### PR DESCRIPTION
Hey,

This PR adds a GitHub action that [on master push] uses a published latex docker container to automatically compile a pdf. I found it useful since for some reason the container proposed in README fails to build on my machine.

This action would create a separate commit in master [that does not retrigger the build] i.e.

<img width="1215" alt="Screenshot 2022-04-10 at 5 22 55 PM" src="https://user-images.githubusercontent.com/947595/162614272-7446f8ca-89bf-4cce-b05e-8753024b7b07.png">

The result of running looks like this:

<img width="1358" alt="Screenshot 2022-04-10 at 5 27 34 PM" src="https://user-images.githubusercontent.com/947595/162614308-25f477ed-7609-4f46-a2d4-2251425b6487.png">

Take a look in case you'd find it usable for yourself or for other users 😄 I have set up this for myself and thought it'd be cool to share. Feel free to adjust it for yourself.

