### PR TITLE
simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM debian:stable-slim
+
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb http://deb.debian.org/debian stable main" > /etc/apt/sources.list && \
-    echo "deb http://deb.debian.org/debian stable-updates main" >> /etc/apt/sources.list && \
-    echo "deb http://deb.debian.org/debian-security stable-security main" >> /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get install -qyf \
-    texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended && \
-    rm -rf /var/lib/apt/lists/*
+RUN echo "deb http://deb.debian.org/debian stable main" > /etc/apt/sources.list \
+    && echo "deb http://deb.debian.org/debian stable-updates main" >> /etc/apt/sources.list \
+    && echo "deb http://deb.debian.org/debian-security stable-security main" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -qy \
+        texlive-latex-recommended \
+        texlive-latex-extra \
+        texlive-fonts-recommended \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /data
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN echo "deb http://deb.debian.org/debian stable main" > /etc/apt/sources.list && \
     echo "deb http://deb.debian.org/debian stable-updates main" >> /etc/apt/sources.list && \
-    echo "deb http://deb.debian.org/debian-security stable-security main" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install -qyf \
-    curl jq make git \
-    python3-pygments gnuplot \
-    texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-RUN rm -rf /var/lib/apt/lists/*
+    echo "deb http://deb.debian.org/debian-security stable-security main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -qyf \
+    texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /data
 VOLUME ["/data"]


### PR DESCRIPTION
- removed `curl`, `jq`, `make`, `git`, `python3-pygments`, and `gnuplot` since they're not used in current GitHub Actions workflow: https://github.com/sb2nov/resume/blob/master/.github/workflows/docker-image.yml
- consolidated RUN commands to reduce number of layers and improve build efficiency
- add `apt-get clean` command to further reduce image size